### PR TITLE
FIX:  Order-disorder model phase building/filtering error #345 

### DIFF
--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -310,11 +310,42 @@ def filter_phases(dbf, comps, candidate_phases=None):
         candidate_phases = dbf.phases.keys()
     else:
         candidate_phases = set(candidate_phases).intersection(dbf.phases.keys())
+    ordered_phases = [dbf.phases[phase].model_hints.get('ordered_phase') for phase in candidate_phases]
     disordered_phases = [dbf.phases[phase].model_hints.get('disordered_phase') for phase in candidate_phases]
-    phases = [phase for phase in candidate_phases if
-                all_sublattices_active(comps, dbf.phases[phase]) and
-                (phase not in disordered_phases or (phase in disordered_phases and
-                dbf.phases[phase].model_hints.get('ordered_phase') not in candidate_phases))]
+    #phases = [phase for phase in candidate_phases if
+    #            all_sublattices_active(comps, dbf.phases[phase]) and
+    #            (phase not in disordered_phases or (phase in disordered_phases and
+    #            dbf.phases[phase].model_hints.get('ordered_phase') not in candidate_phases))]
+
+    # Initial list of phases will be any phases that is not an order/disordered model
+    phases = [phase for phase in candidate_phases if 
+              all_sublattices_active(comps, dbf.phases[phase]) and
+              (phase not in disordered_phases) and
+              (phase not in ordered_phases)]
+    
+    # Go through list of all order/disordered models
+    for ord_phase, dis_phase in zip(ordered_phases, disordered_phases):
+        if ord_phase is not None:
+            # Don't duplicate phases
+            if ord_phase not in phases and dis_phase not in phases:
+                if all_sublattices_active(comps, dbf.phases[ord_phase]) and all_sublattices_active(comps, dbf.phases[dis_phase]):
+                    # All active components in the ordered and disordered part of the phase
+                    active_ord_comps = set.union(*[set(comps).intersection(subl) for subl in dbf.phases[ord_phase].constituents])
+                    active_dis_comps = set.union(*[set(comps).intersection(subl) for subl in dbf.phases[dis_phase].constituents])
+
+                    #If user explicitly specifies the disordered phase, then add the disordered phase in place of the ordered phase
+                    ord_phase_alias = ord_phase if ord_phase in candidate_phases else dis_phase
+
+                    # If active components for ordered and disordered phases are the same, then use ordered phase
+                    if len(active_dis_comps.symmetric_difference(active_ord_comps)) == 0:
+                        phases.append(ord_phase_alias)
+                    # If ordered phase components is a subset of disordered phase components, then use disordered phase
+                    elif len(active_dis_comps - active_ord_comps) > 0:
+                        phases.append(dis_phase)
+                    # If more active components in ordered phase, add ordered phase, in Model, this will build
+                    # the ordered phase for the active disordered components
+                    elif len(active_ord_comps - active_dis_comps) > 0:
+                        phases.append(ord_phase_alias)
     return sorted(phases)
 
 

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -312,21 +312,17 @@ def filter_phases(dbf, comps, candidate_phases=None):
         candidate_phases = set(candidate_phases).intersection(dbf.phases.keys())
     ordered_phases = [dbf.phases[phase].model_hints.get('ordered_phase') for phase in candidate_phases]
     disordered_phases = [dbf.phases[phase].model_hints.get('disordered_phase') for phase in candidate_phases]
-    #phases = [phase for phase in candidate_phases if
-    #            all_sublattices_active(comps, dbf.phases[phase]) and
-    #            (phase not in disordered_phases or (phase in disordered_phases and
-    #            dbf.phases[phase].model_hints.get('ordered_phase') not in candidate_phases))]
 
-    # Initial list of phases will be any phases that is not an order/disordered model
+    # First add all phases that are not order/disorder models
     phases = [phase for phase in candidate_phases if 
               all_sublattices_active(comps, dbf.phases[phase]) and
               (phase not in disordered_phases) and
               (phase not in ordered_phases)]
     
-    # Go through list of all order/disordered models
+    # Go through list of all order/disorder models
     for ord_phase, dis_phase in zip(ordered_phases, disordered_phases):
         if ord_phase is not None:
-            # Don't duplicate phases
+            # Don't duplicate phases (both ordered and disordered phases will have the same ordered_phase and disordered_phase hints)
             if ord_phase not in phases and dis_phase not in phases:
                 if all_sublattices_active(comps, dbf.phases[ord_phase]) and all_sublattices_active(comps, dbf.phases[dis_phase]):
                     # All active components in the ordered and disordered part of the phase

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -206,6 +206,16 @@ class Model(object):
                 else:
                     raise ValueError('Two-sublattice ionic liquid specified with more than two sublattices')
                 self.site_ratios[subl_idx] = Add(*[v.SiteFraction(self.phase_name, idx, spec) * abs(spec.charge) for spec in subl_comps])
+        # If the phase is order/disordered model, then filter the components to the set of species in the disordered model
+        # This will account for the case where the ordered contribution has more components than the disordered model
+        if phase.model_hints.get('disordered_phase', False):
+            disordered_phase = phase.model_hints.get('disordered_phase')
+            disordered_phase_comps = set()
+            for idx, sublattice in enumerate(dbe.phases[disordered_phase].constituents):
+                subl_comps = set(sublattice).intersection(active_species)
+                disordered_phase_comps |= subl_comps
+            self.components = self.components.intersection(disordered_phase_comps)
+        
         if phase.model_hints.get('ionic_liquid_2SL', False):
             # Special treatment of "neutral" vacancies in 2SL ionic liquid
             # These are treated as having variable valence
@@ -1235,8 +1245,13 @@ class Model(object):
         # with the disordered phase.
         # Assumes first sublattice of the disordered phase is the sublattice
         # that can be come ordered:
-        disordered_subl_constituents = disordered_phase.constituents[0]
-        ordered_constituents = ordered_phase.constituents
+        # Rather than using the constituents defined in the model, we want to compare the
+        # subset of the consituents defined by the components (which accounts for the active
+        # components set by the user)
+        disordered_subl_constituents = disordered_phase.constituents[0].intersection(self.components)
+        ordered_constituents = constituents
+        #disordered_subl_constituents = disordered_phase.constituents[0]
+        #ordered_constituents = ordered_phase.constituents
         substitutional_sublattice_idxs = []
         for idx, subl_constituents in enumerate(ordered_constituents):
             # Assumes that the ordered phase sublattice describes the ordering

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -1250,8 +1250,6 @@ class Model(object):
         # components set by the user)
         disordered_subl_constituents = disordered_phase.constituents[0].intersection(self.components)
         ordered_constituents = constituents
-        #disordered_subl_constituents = disordered_phase.constituents[0]
-        #ordered_constituents = ordered_phase.constituents
         substitutional_sublattice_idxs = []
         for idx, subl_constituents in enumerate(ordered_constituents):
             # Assumes that the ordered phase sublattice describes the ordering

--- a/pycalphad/tests/test_utils.py
+++ b/pycalphad/tests/test_utils.py
@@ -183,3 +183,117 @@ def test_generating_symmetric_group_works_with_interstitial_sublattice():
         ("A", "B", "VA", "A", "A"),
         ("B", "A", "VA", "A", "A"),
     ]
+
+def test_filter_ordered_disordered_phases_with_unmatched_constituents():
+    # Ordered phase has more constituents than disordered phase
+    TDB = """
+    ELEMENT A   PHASE             0.0                0.00            0.00      !
+    ELEMENT B   PHASE             0.0                0.00            0.00      !
+    ELEMENT C   PHASE             0.0                0.00            0.00      !
+    ELEMENT D   PHASE             0.0                0.00            0.00      !
+    ELEMENT VA  VACUUM            0.0                0.00            0.00      !
+
+    TYPE_DEFINITION X GES AMEND_PHASE_DESCRIPTION BCC_B2 DIS_PART BCC_A2 !
+
+    PHASE BCC_B2 X  3 0.5 0.5   3 !
+    CONSTITUENT BCC_B2  : A,B,C,D : A,B,C,D : VA : !
+    PHASE BCC_A2  X  2 1   3 !
+    CONSTITUENT BCC_A2  :A,B,C : VA :  !
+    """
+
+    # Ordered phase has different (but same length) set of constituents
+    TDB2 = """
+    ELEMENT A   PHASE             0.0                0.00            0.00      !
+    ELEMENT B   PHASE             0.0                0.00            0.00      !
+    ELEMENT C   PHASE             0.0                0.00            0.00      !
+    ELEMENT D   PHASE             0.0                0.00            0.00      !
+    ELEMENT VA  VACUUM            0.0                0.00            0.00      !
+
+    TYPE_DEFINITION X GES AMEND_PHASE_DESCRIPTION BCC_B2 DIS_PART BCC_A2 !
+
+    PHASE BCC_B2 X  3 0.5 0.5   3 !
+    CONSTITUENT BCC_B2  : B,C,D : B,C,D : VA : !
+    PHASE BCC_A2  X  2 1   3 !
+    CONSTITUENT BCC_A2  :A,B,C : VA :  !
+    """
+
+    # Ordered phase has less constituents than disordered phase
+    TDB3 = """
+    ELEMENT A   PHASE             0.0                0.00            0.00      !
+    ELEMENT B   PHASE             0.0                0.00            0.00      !
+    ELEMENT C   PHASE             0.0                0.00            0.00      !
+    ELEMENT D   PHASE             0.0                0.00            0.00      !
+    ELEMENT VA  VACUUM            0.0                0.00            0.00      !
+
+    TYPE_DEFINITION X GES AMEND_PHASE_DESCRIPTION BCC_B2 DIS_PART BCC_A2 !
+
+    PHASE BCC_B2 X  3 0.5 0.5   3 !
+    CONSTITUENT BCC_B2  : A,B,C : A,B,C : VA : !
+    PHASE BCC_A2  X  2 1   3 !
+    CONSTITUENT BCC_A2  :A,B,C,D : VA :  !
+    """
+    from pycalphad import variables as v
+
+    dbf1 = Database(TDB)
+    dbf2 = Database(TDB2)
+    dbf3 = Database(TDB3)
+
+    # dbf1 gives BCC_B2 with [A, B, C, VA] as components
+    # dbf2 gives BCC_A2 with [A, B, C, VA] as components
+    # dbf3 gives BCC_B2 with [A, B, C, VA] as components
+    comps = ['A', 'B', 'C', 'VA']
+    
+    phases1 = filter_phases(dbf1, unpack_components(dbf1, comps))
+    model1 = Model(dbf1, comps, phases1[0])
+    assert len(phases1) == 1 and 'BCC_B2' in phases1
+    assert len(set([v.Species('A'), v.Species('B'), v.Species('C'), v.Species('VA')]).symmetric_difference(model1.components)) == 0
+   
+    phases2 = filter_phases(dbf2, unpack_components(dbf2, comps))
+    model2 = Model(dbf2, comps, phases2[0])
+    assert len(phases2) == 1 and 'BCC_A2' in phases2
+    assert len(set([v.Species('A'), v.Species('B'), v.Species('C'), v.Species('VA')]).symmetric_difference(model2.components)) == 0
+
+    phases3 = filter_phases(dbf3, unpack_components(dbf3, comps))
+    model3 = Model(dbf3, comps, phases3[0])
+    assert len(phases3) == 1 and 'BCC_B2' in phases3
+    assert len(set([v.Species('A'), v.Species('B'), v.Species('C'), v.Species('VA')]).symmetric_difference(model3.components)) == 0
+
+    # dbf1 gives BCC_B2 with [A, B, C, VA] as components
+    # dbf2 gives BCC_A2 with [A, B, C, VA] as components
+    # dbf3 gives BCC_A2 with [A, B, C, D, VA] as components
+    comps = ['A', 'B', 'C', 'D', 'VA']
+
+    phases1 = filter_phases(dbf1, unpack_components(dbf1, comps))
+    model1 = Model(dbf1, comps, phases1[0])
+    assert len(phases1) == 1 and 'BCC_B2' in phases1
+    assert len(set([v.Species('A'), v.Species('B'), v.Species('C'), v.Species('VA')]).symmetric_difference(model1.components)) == 0
+   
+    phases2 = filter_phases(dbf2, unpack_components(dbf2, comps))
+    model2 = Model(dbf2, comps, phases2[0])
+    assert len(phases2) == 1 and 'BCC_A2' in phases2
+    assert len(set([v.Species('A'), v.Species('B'), v.Species('C'), v.Species('VA')]).symmetric_difference(model2.components)) == 0
+    
+    phases3 = filter_phases(dbf3, unpack_components(dbf3, comps))
+    model3 = Model(dbf3, comps, phases3[0])
+    assert len(phases3) == 1 and 'BCC_A2' in phases3
+    assert len(set([v.Species('A'), v.Species('B'), v.Species('C'), v.Species('D'), v.Species('VA')]).symmetric_difference(model3.components)) == 0
+
+    # dbf1 gives BCC_B2 with [B, C, VA] as components
+    # dbf2 gives BCC_B2 with [B, C, VA] as components
+    # dbf3 gives BCC_A2 with [B, C, D, VA] as components
+    comps = ['B', 'C', 'D', 'VA']
+
+    phases1 = filter_phases(dbf1, unpack_components(dbf1, comps))
+    model1 = Model(dbf1, comps, phases1[0])
+    assert len(phases1) == 1 and 'BCC_B2' in phases1
+    assert len(set([v.Species('B'), v.Species('C'), v.Species('VA')]).symmetric_difference(model1.components)) == 0
+   
+    phases2 = filter_phases(dbf2, unpack_components(dbf2, comps))
+    model2 = Model(dbf2, comps, phases2[0])
+    assert len(phases2) == 1 and 'BCC_B2' in phases2
+    assert len(set([v.Species('B'), v.Species('C'), v.Species('VA')]).symmetric_difference(model2.components)) == 0
+    
+    phases3 = filter_phases(dbf3, unpack_components(dbf3, comps))
+    model3 = Model(dbf3, comps, phases3[0])
+    assert len(phases3) == 1 and 'BCC_A2' in phases3
+    assert len(set([v.Species('B'), v.Species('C'), v.Species('D'), v.Species('VA')]).symmetric_difference(model3.components)) == 0


### PR DESCRIPTION
This fixes #345 which filters ordered/disordered phases that have unmatched constituents under the following conditions:
- If active components in ordered part matches disordered part -> build phase model for ordered phase
- If active components in ordered part is less than disordered part -> build phase model for disordered phase
- If active components in ordered part is greater than disordered part -> build phase model for ordered phase (using intersection of active components in ordered and disordered part
- If user specifies the disordered phase the candidate_phases list, then the ordered phase will be replaced with the disordered phase